### PR TITLE
(testing): add unit tests for the NamespaceScopedCache `Get()` and `List()` functions

### DIFF
--- a/pkg/cache/namespace/namespace_cache.go
+++ b/pkg/cache/namespace/namespace_cache.go
@@ -243,12 +243,21 @@ func (nsc *NamespaceScopedCache) Start() {
 	nsc.started = true
 }
 
+// Terminate will shutdown all informers in the cache and
+// then proceed to shutdown the cache.
 func (nsc *NamespaceScopedCache) Terminate() {
 	nsc.mu.Lock()
 	defer nsc.mu.Unlock()
 	for nsKey := range nsc.Namespaces {
 		for gvkKey := range nsc.Namespaces[nsKey] {
 			for _, si := range nsc.Namespaces[nsKey][gvkKey] {
+				// TODO: because terminating the informers cancels
+				// the context they were using to run these informers won't
+				// be able to be run again. This makes the Terminate() function
+				// more like a "Kill" signal and is not a graceful shutdown of the
+				// cache. In order to make this more graceful, we should update the
+				// ScopeInformer termination logic to create a new context to be used
+				// in the event the cache is restarted.
 				si.Terminate()
 			}
 		}

--- a/pkg/cache/namespace/namespace_cache.go
+++ b/pkg/cache/namespace/namespace_cache.go
@@ -59,7 +59,6 @@ func (nsc *NamespaceScopedCache) Get(key types.NamespacedName, gvk schema.GroupV
 
 	// Loop through all informers and attempt to get the requested resource
 	for _, si := range nsc.Namespaces[key.Namespace][gvk] {
-		fmt.Println(si)
 		obj, err = si.Get(key.String())
 		if err != nil {
 			// ignore error because it *could* be found by another informer

--- a/pkg/cache/namespace/namespace_cache_test.go
+++ b/pkg/cache/namespace/namespace_cache_test.go
@@ -1,7 +1,6 @@
 package namespace
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -13,9 +12,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("NamespaceScopedCache Unit Tests", func() {
@@ -231,13 +230,13 @@ var _ = Describe("NamespaceScopedCache Unit Tests", func() {
 		})
 	})
 
-	When("Getting resources with NamespaceScopedCache.Get()", func() {
+	Context("Retrieving resources", func() {
 		BeforeEach(func() {
 			nsCache.AddInformer(infOpts)
 			nsCache.Start()
 
 			started := func() bool {
-				return nsCache.IsStarted()
+				return nsCache.Synced()
 			}
 			Eventually(started).Should(BeTrue())
 		})
@@ -245,50 +244,108 @@ var _ = Describe("NamespaceScopedCache Unit Tests", func() {
 		AfterEach(func() {
 			nsCache.Terminate()
 		})
+		When("Getting resources with NamespaceScopedCache.Get()", func() {
+			It("Should return an InformerNotFoundErr if the provided Namespace doesn't exist in the cache", func() {
+				obj, err := nsCache.Get(types.NamespacedName{Namespace: "noinformers", Name: "test"}, appsv1.SchemeGroupVersion.WithKind("Deployment"))
+				Expect(obj).Should(BeNil())
+				Expect(err).ShouldNot(BeNil())
+				Expect(errors.IsInformerNotFoundErr(err)).Should(BeTrue())
+				Expect(err.Error()).Should(Equal("no informers at the namespace level exist for namespace \"noinformers\""))
+			})
 
-		It("Should return an InformerNotFoundErr if the provided Namespace doesn't exist in the cache", func() {
-			obj, err := nsCache.Get(types.NamespacedName{Namespace: "noinformers", Name: "test"}, appsv1.SchemeGroupVersion.WithKind("Deployment"))
-			Expect(obj).Should(BeNil())
-			Expect(err).ShouldNot(BeNil())
-			Expect(errors.IsInformerNotFoundErr(err)).Should(BeTrue())
-			Expect(err.Error()).Should(Equal("no informers at the namespace level exist for namespace \"noinformers\""))
+			It("Should return an InformerNotFoundErr if no informers for the provided GVK are found in the Namespace", func() {
+				gvk := appsv1.SchemeGroupVersion.WithKind("Deployment")
+				ns := "test-ns"
+				obj, err := nsCache.Get(types.NamespacedName{Namespace: ns, Name: "test"}, gvk)
+				Expect(obj).Should(BeNil())
+				Expect(err).ShouldNot(BeNil())
+				Expect(errors.IsInformerNotFoundErr(err)).Should(BeTrue())
+				Expect(err.Error()).Should(Equal(fmt.Sprintf("no informers at the namespace level exist in namespace %q for GVK %q", ns, gvk)))
+			})
+
+			It("Should return an error if the requested resource could not be found", func() {
+				gvk := corev1.SchemeGroupVersion.WithKind("Pod")
+				ns := "test-ns"
+				obj, err := nsCache.Get(types.NamespacedName{Namespace: ns, Name: "test"}, gvk)
+				Expect(obj).Should(BeNil())
+				Expect(err).ShouldNot(BeNil())
+				Expect(apierrors.IsNotFound(err)).Should(BeTrue())
+			})
+
+			It("Should return the runtime.Object if the resource could be found", func() {
+				gvk := corev1.SchemeGroupVersion.WithKind("Pod")
+				ns := "test-ns"
+				obj, err := nsCache.Get(types.NamespacedName{Namespace: ns, Name: "test-pod-0"}, gvk)
+				Expect(err).Should(BeNil())
+				Expect(obj).ShouldNot(BeNil())
+				pod, ok := obj.(*corev1.Pod)
+				Expect(ok).Should(BeTrue())
+				Expect(pod.Name).Should(Equal("test-pod-0"))
+				Expect(pod.Namespace).Should(Equal(ns))
+				Expect(len(pod.Spec.Containers)).Should(Equal(1))
+				Expect(pod.Spec.Containers[0].Name).Should(Equal("nginx"))
+				Expect(pod.Spec.Containers[0].Image).Should(Equal("nginx:1.14.2"))
+			})
 		})
 
-		It("Should return an InformerNotFoundErr if no informers for the provided GVK are found in the Namespace", func() {
-			gvk := appsv1.SchemeGroupVersion.WithKind("Deployment")
-			ns := "test-ns"
-			obj, err := nsCache.Get(types.NamespacedName{Namespace: ns, Name: "test"}, gvk)
-			Expect(obj).Should(BeNil())
-			Expect(err).ShouldNot(BeNil())
-			Expect(errors.IsInformerNotFoundErr(err)).Should(BeTrue())
-			Expect(err.Error()).Should(Equal(fmt.Sprintf("no informers at the namespace level exist in namespace %q for GVK %q", ns, gvk)))
-		})
+		When("Listing resources with NamespaceScopedCache.List()", func() {
+			It("Should return an InformerNotFoundError if ListOpts.Namespace doesn't exist in the cache", func() {
+				objs, err := nsCache.List(client.ListOptions{Namespace: "noinformers"}, appsv1.SchemeGroupVersion.WithKind("Deployment"))
+				Expect(objs).Should(BeNil())
+				Expect(err).ShouldNot(BeNil())
+				Expect(errors.IsInformerNotFoundErr(err)).Should(BeTrue())
+				Expect(err.Error()).Should(Equal("no informers at the namespace level exist for namespace \"noinformers\""))
+			})
 
-		It("Should return an error if the requested resource could not be found", func() {
-			gvk := corev1.SchemeGroupVersion.WithKind("Pod")
-			ns := "test-ns"
-			obj, err := nsCache.Get(types.NamespacedName{Namespace: ns, Name: "test"}, gvk)
-			Expect(obj).Should(BeNil())
-			Expect(err).ShouldNot(BeNil())
-			Expect(apierrors.IsNotFound(err)).Should(BeTrue())
-		})
+			It("Should return an InformerNotFoundError if ListOpts.Namespace exists but there is no informer for the GVK", func() {
+				gvk := appsv1.SchemeGroupVersion.WithKind("Deployment")
+				ns := "test-ns"
+				objs, err := nsCache.List(client.ListOptions{Namespace: ns}, gvk)
+				Expect(objs).Should(BeNil())
+				Expect(err).ShouldNot(BeNil())
+				Expect(errors.IsInformerNotFoundErr(err)).Should(BeTrue())
+				Expect(err.Error()).Should(Equal(fmt.Sprintf("no informers at the namespace level exist in namespace %q for GVK %q", ns, gvk)))
+			})
 
-		It("Should return the runtime.Object if the resource could be found", func() {
-			createResources()
-			gvk := corev1.SchemeGroupVersion.WithKind("Pod")
-			ns := "test-ns"
-			obj, err := nsCache.Get(types.NamespacedName{Namespace: ns, Name: "test-pod-0"}, gvk)
-			Expect(err).Should(BeNil())
-			Expect(obj).ShouldNot(BeNil())
-			pod, ok := obj.(*corev1.Pod)
-			Expect(ok).Should(BeTrue())
-			Expect(pod.Name).Should(Equal("test-pod-0"))
-			Expect(pod.Namespace).Should(Equal(ns))
-			Expect(len(pod.Spec.Containers)).Should(Equal(1))
-			Expect(pod.Spec.Containers[0].Name).Should(Equal("nginx"))
-			Expect(pod.Spec.Containers[0].Image).Should(Equal("nginx:1.14.2"))
+			It("Should return a list of all requested resources from the requested Namespace", func() {
+				gvk := corev1.SchemeGroupVersion.WithKind("Pod")
+				ns := "test-ns"
+				objs, err := nsCache.List(client.ListOptions{Namespace: ns}, gvk)
+				Expect(err).Should(BeNil())
+				Expect(objs).ShouldNot(BeNil())
+				// Due to the nature of this test having to delete
+				// and recreate resources we can't guarantee that there will be
+				// an exact number of resources so we just make sure there are some
+				Expect(len(objs)).Should(BeNumerically(">", 0))
+				for _, obj := range objs {
+					pod, ok := obj.(*corev1.Pod)
+					Expect(ok).Should(BeTrue())
+					Expect(pod.Name).Should(ContainSubstring("test-pod-"))
+					Expect(pod.Namespace).Should(Equal(ns))
+					Expect(len(pod.Spec.Containers)).Should(Equal(1))
+					Expect(pod.Spec.Containers[0].Name).Should(Equal("nginx"))
+					Expect(pod.Spec.Containers[0].Image).Should(Equal("nginx:1.14.2"))
+				}
+			})
+
+			It("Should attempt to list from all namespaces in the cache that contain an informer for this GVK", func() {
+				gvk := corev1.SchemeGroupVersion.WithKind("Pod")
+				objs, err := nsCache.List(client.ListOptions{}, gvk)
+				Expect(err).Should(BeNil())
+				Expect(objs).ShouldNot(BeNil())
+				// Due to the nature of this test having to delete
+				// and recreate resources we can't guarantee that there will be
+				// an exact number of resources so we just make sure there are some
+				Expect(len(objs)).Should(BeNumerically(">", 0))
+				for _, obj := range objs {
+					// verify that each object is a Pod
+					_, ok := obj.(*corev1.Pod)
+					Expect(ok).Should(BeTrue())
+				}
+			})
 		})
 	})
+
 })
 
 // verifyMappings is a helper function to ensure
@@ -298,42 +355,4 @@ func verifyMappings(nsCache *NamespaceScopedCache, infOpts components.InformerOp
 	Expect(nsCache.Namespaces).Should(HaveKey(infOpts.Namespace))
 	Expect(nsCache.Namespaces[infOpts.Namespace]).Should(HaveKey(infOpts.Gvk))
 	Expect(nsCache.Namespaces[infOpts.Namespace][infOpts.Gvk]).Should(HaveKey(infOpts.Key))
-}
-
-func createResources() {
-	// initialize a namespace named "test-ns"
-	// with 5 pods named in the pattern "test-pod-#"
-	namespace := "test-ns"
-	createNs := func() error {
-		_, err := k8sClient.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: namespace}}, v1.CreateOptions{})
-		return err
-	}
-	Eventually(createNs).ShouldNot(HaveOccurred())
-
-	for i := 0; i < 5; i++ {
-		expPod := &corev1.Pod{
-			ObjectMeta: v1.ObjectMeta{
-				Namespace: namespace,
-				Name:      fmt.Sprintf("test-pod-%d", i),
-			},
-			Spec: corev1.PodSpec{
-				Containers: []corev1.Container{
-					{
-						Name:  "nginx",
-						Image: "nginx:1.14.2",
-						Ports: []corev1.ContainerPort{
-							{
-								ContainerPort: 80,
-							},
-						},
-					},
-				},
-			},
-		}
-		createPod := func() error {
-			_, err := k8sClient.CoreV1().Pods(namespace).Create(context.Background(), expPod, v1.CreateOptions{})
-			return err
-		}
-		Eventually(createPod).ShouldNot(HaveOccurred())
-	}
 }

--- a/pkg/cache/namespace/namespace_suite_test.go
+++ b/pkg/cache/namespace/namespace_suite_test.go
@@ -6,6 +6,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -25,9 +27,13 @@ func TestComponents(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	testEnv = &envtest.Environment{}
+	scheme := runtime.NewScheme()
+	err := corev1.AddToScheme(scheme)
+	Expect(err).Should(BeNil())
 
-	var err error
+	testEnv = &envtest.Environment{
+		Scheme: scheme,
+	}
 
 	// cfg is defined in this file globally.
 	cfg, err = testEnv.Start()

--- a/pkg/cache/namespace/namespace_suite_test.go
+++ b/pkg/cache/namespace/namespace_suite_test.go
@@ -1,12 +1,16 @@
 package namespace
 
 import (
+	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -43,8 +47,60 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = kubernetes.NewForConfig(cfg)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
+	// create the test resources
+	createResources()
 })
 
 var _ = AfterSuite(func() {
+	// clean up the test namespace
+	deleteResources()
 	Expect(testEnv.Stop()).ShouldNot(HaveOccurred())
 })
+
+func createResources() {
+	namespace := "test-ns"
+	createNs := func() error {
+		_, err := k8sClient.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: namespace}}, v1.CreateOptions{})
+		return err
+	}
+	Eventually(createNs).ShouldNot(HaveOccurred())
+	// initialize a namespace named "test-ns"
+	// with 5 pods named in the pattern "test-pod-#"
+	for i := 0; i < 5; i++ {
+		expPod := &corev1.Pod{
+			ObjectMeta: v1.ObjectMeta{
+				Namespace: namespace,
+				Name:      fmt.Sprintf("test-pod-%d", i),
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "nginx",
+						Image: "nginx:1.14.2",
+						Ports: []corev1.ContainerPort{
+							{
+								ContainerPort: 80,
+							},
+						},
+					},
+				},
+			},
+		}
+		createPod := func() error {
+			_, err := k8sClient.CoreV1().Pods(namespace).Create(context.Background(), expPod, v1.CreateOptions{})
+			return err
+		}
+		Eventually(createPod).ShouldNot(HaveOccurred())
+	}
+}
+
+func deleteResources() {
+	// initialize a namespace named "test-ns"
+	// with 5 pods named in the pattern "test-pod-#"
+	namespace := "test-ns"
+	for i := 0; i < 5; i++ {
+		Expect(k8sClient.CoreV1().Pods(namespace).Delete(context.Background(), fmt.Sprintf("test-pod-%d", i), metav1.DeleteOptions{})).ShouldNot(HaveOccurred())
+	}
+
+	Expect(k8sClient.CoreV1().Namespaces().Delete(context.Background(), namespace, v1.DeleteOptions{}))
+}


### PR DESCRIPTION
**Description:**
- Add unit tests for the `NamespaceScopedCache` `Get()` and `List()` functions
- Add a new function `Terminate()` to `NamespaceScopedCache` to shutdown the cache and it's informers

**Motivation**
- resolves partially #9